### PR TITLE
Include admin and admindocs template paths in (TEMPLATES.DIRS).

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -1,8 +1,10 @@
+import os
+
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
-
+DJANGO_DIR = BASE_DIR.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
@@ -42,7 +44,10 @@ ROOT_URLCONF = "main.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [
+            os.path.join(DJANGO_DIR, "django/contrib/admin/templates"),
+            os.path.join(DJANGO_DIR, "django/contrib/admindocs/templates"),
+        ],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
I added the template paths to TEMPLATES.DIRS so that changes to the cloned Django templates are reflected.